### PR TITLE
Fix overlaping checkmarks in Boost theme (same as MDL-60359)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -19,6 +19,13 @@
     text-indent: 0;
 }
 
+.que.multichoiceset .answer div.r0 .icon.fa-check,
+.que.multichoiceset .answer div.r1 .icon.fa-check,
+.que.multichoiceset .answer div.r0 .icon.fa-remove,
+.que.multichoiceset .answer div.r1 .icon.fa-remove {
+    text-indent: 0;
+}
+
 .que.multichoiceset .answer div.r0 input,
 .que.multichoiceset .answer div.r1 input {
     margin: 0 5px;


### PR DESCRIPTION
Hello Eoin,
German Valero reported a small problem in the Boost theme that I fixed the same way that the core multichoice question type was fixed a few weeks ago in MDL-60359.
Please can you integrate this in your next release. Thanks