### PR TITLE
MDL-57281 - fix behat step

### DIFF
--- a/tests/behat/backup_and_restore.feature
+++ b/tests/behat/backup_and_restore.feature
@@ -28,7 +28,7 @@ Feature: Test duplicating a quiz containing a All-or-Nothing Multiple Choice que
       | Confirmation | Filename | test_backup.mbz |
     And I restore "test_backup.mbz" backup into a new course using this options:
       | Schema | Course name | Course 2 |
-    And I navigate to "Question bank" node in "Course administration"
+    And I navigate to "Question bank" in current page administration
     And I click on "Edit" "link" in the "All-or-nothing-001" "table_row"
     Then the following fields match these values:
       | Question name                      | All-or-nothing-001                 |


### PR DESCRIPTION
Fixes the below failing scenario

@javascript
  Scenario: Backup and restore a course containing a All-or-Nothing Multiple Choic question # /var/www/html/question/type/multichoiceset/tests/behat/backup_and_restore.feature:26
    When I backup "Course 1" course using this options:                                     # behat_hooks::i_look_for_exceptions()
      | Confirmation | Filename | test_backup.mbz |
    And I restore "test_backup.mbz" backup into a new course using this options:            # behat_hooks::i_look_for_exceptions()
      | Schema | Course name | Course 2 |
    And I navigate to "Question bank" node in "Course administration"
    â”‚
    â•³  Coding error detected, it must be fixed by a programmer: Step 'I navigate to "Question bank" node in "Course administration"'' is undefined. (coding_exception)
    â”‚
    â””â”€ @AfterStep # behat_hooks::after_step_javascript()
    And I click on "Edit" "link" in the "All-or-nothing-001" "table_row" 