### PR TITLE
Update lib.php

### DIFF
--- a/backup/moodle1/lib.php
+++ b/backup/moodle1/lib.php
@@ -68,7 +68,7 @@ class moodle1_qtype_multichoiceset_handler extends moodle1_qtype_handler {
                 'incorrectfeedback'              => '',
                 'incorrectfeedbackformat'        => FORMAT_HTML,
                 'answernumbering'                => 'abc',
-                'shownumcorrect'                => 0
+                'shownumcorrect'                => 0,
                 'showstandardinstruction'        => 0
             ));
         }


### PR DESCRIPTION
Fix missing comma as reported by Azmat.
I guess that not many people use that feature now to import very old backups so this is why this bug remains unnoticed until now.