### PR TITLE
Fix behat test

### DIFF
--- a/tests/behat/backup_and_restore.feature
+++ b/tests/behat/backup_and_restore.feature
@@ -30,6 +30,7 @@ Feature: Test duplicating a quiz containing a All-or-Nothing Multiple Choice que
       | Schema | Course name | Course 2 |
     And I navigate to "Question bank" in current page administration
     And I click on "Edit" "link" in the "All-or-nothing-001" "table_row"
+    And I follow "Edit question"
     Then the following fields match these values:
       | Question name                      | All-or-nothing-001                 |
       | Question text                      | Which are the odd numbers?         |

--- a/tests/behat/edit.feature
+++ b/tests/behat/edit.feature
@@ -26,6 +26,7 @@ Feature: Test editing a All-or-Nothing Multiple Choice question
 
   Scenario: Edit a All-or-Nothing Multiple Choice question
     When I click on "Edit" "link" in the "All-or-nothing for editing" "table_row"
+    And I follow "Edit question"
     And I set the following fields to these values:
       | Question name | |
     And I press "id_submitbutton"


### PR DESCRIPTION
The following tests fail in moodle 3.8 and higher:
backup_and_restore.feature
edit.feature

In moodle 3.7 there was a button to edit the questions, in 3.8 this changed to a dropdown, so when running the behat test fails because it only opens the menu, this can be solved by adding a step to go to the editing of the questions.