### PR TITLE
Fix fatal error

### DIFF
--- a/tests/question_test.php
+++ b/tests/question_test.php
@@ -22,7 +22,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-namespace qtype_multichoiceset;
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;

--- a/tests/questiontype_test.php
+++ b/tests/questiontype_test.php
@@ -22,7 +22,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-namespace qtype_multichoiceset;
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;

--- a/tests/walkthrough_test.php
+++ b/tests/walkthrough_test.php
@@ -26,7 +26,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-namespace qtype_multichoiceset;
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;


### PR DESCRIPTION
Same issue as https://github.com/ecampbell/moodle-qformat_wordtable/issues/22 namespace causes fatal error when running behat & phpunit on moodle 4.5